### PR TITLE
Use pkg-config to find libftdi1 instead of hardwired directories

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,9 +1,7 @@
 
 CC = g++
-CFLAGS = -I. -std=gnu++11 -D_DEBUG -ggdb -I/usr/local/include/libftdi1
-LFLAGS = -L/usr/local/lib
-LIBS = -lftdi1
-#LIBS = /usr/local/lib/libftdi1.so.2.4.0
+CFLAGS = -I. -std=gnu++11 -D_DEBUG -ggdb `pkg-config --cflags libftdi1`
+LFLAGS = `pkg-config --libs libftdi1`
 TARGET = ftdi_prog
 
 HEADERS = Options.hpp ftdi_dev.hpp
@@ -21,7 +19,7 @@ all: default
 	$(CC) $(CFLAGS) -c $< -o $@
 
 $(TARGET): $(OBJS)
-	$(CC) $(OBJS) -Wall $(LFLAGS) $(LIBS) -o $@
+	$(CC) $(OBJS) -Wall $(LFLAGS) -o $@
 
 clean:
 	-rm -f $(OBJS)


### PR DESCRIPTION
Modern Linuxes have libftdi1 available. Use pkg_config to find it.