### PR TITLE
Adding pkg-config in Make file to support libftdi1 default install

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,8 +1,8 @@
 
 CC = g++
-CFLAGS = -I. -std=gnu++11 -D_DEBUG -ggdb -I/usr/local/include/libftdi1
-LFLAGS = -L/usr/local/lib
-LIBS = -lftdi1
+CFLAGS = -I. -std=gnu++11 -D_DEBUG -ggdb `pkg-config --cflags libftdi1`
+#LFLAGS = -L/usr/local/lib
+LIBS = `pkg-config --libs libftdi1`
 #LIBS = /usr/local/lib/libftdi1.so.2.4.0
 TARGET = ftdi_prog
 

--- a/README.md
+++ b/README.md
@@ -6,8 +6,9 @@ http://www.ftdichip.com/Support/Documents/AppNotes/AN_124_User_Guide_For_FT_PROG
 
 #### Required package
 - libftdi 1.4
-  Installed under /usr/local
-```$ cmake -DCMAKE_INSTALL_PREFIX="/usr/local" ../```
+  ~~installed under /usr/local~~
+~~```$ cmake -DCMAKE_INSTALL_PREFIX="/usr/local" ../```~~
+  Modified to use pkg-config since libftdi1 is available on a lot of distribution.
 
 #### Compile & Run
 If the local built libftdi is not installed in one of the system directories


### PR DESCRIPTION
Just modified the Make file to add a basic support of pkg-config to ease the compilation on recent distribution.